### PR TITLE
changed pandas_udf apply wrapping to be in one place

### DIFF
--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -248,7 +248,6 @@ class GroupedData(object):
         # So we to create a wrapper function that turns that to a pd.DataFrame before passing
         # down to the user function, then turn the result pd.DataFrame back into pd.Series
         columns = df.columns
-        arrow_return_types = [to_arrow_type(field.dataType) for field in returnType]
 
         def wrapped(*cols):
             import pandas as pd
@@ -256,13 +255,14 @@ class GroupedData(object):
             if not isinstance(result, pd.DataFrame):
                 raise TypeError("Return type of the user-defined function should be "
                                 "Pandas.DataFrame, but is {}".format(type(result)))
-            if not len(result.columns) == len(arrow_return_types):
+            if not len(result.columns) == len(returnType):
                 raise RuntimeError(
                     "Number of columns of the returned Pandas.DataFrame "
                     "doesn't match specified schema. "
-                    "Expected: {} Actual: {}".format(len(arrow_return_types), len(result.columns)))
-            return [(result[result.columns[i]], arrow_return_types[i])
-                    for i in range(len(arrow_return_types))]
+                    "Expected: {} Actual: {}".format(len(returnType), len(result.columns)))
+            arrow_return_types = (to_arrow_type(field.dataType) for field in returnType)
+            return [(result[result.columns[i]], arrow_type)
+                    for i, arrow_type in enumerate(arrow_return_types)]
 
         wrapped_udf_obj = pandas_udf(wrapped, returnType)
         udf_column = wrapped_udf_obj(*[df[col] for col in df.columns])

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -232,7 +232,6 @@ class GroupedData(object):
 
         """
         from pyspark.sql.functions import pandas_udf
-        from pyspark.sql.types import to_arrow_type
 
         # Columns are special because hasattr always return True
         if isinstance(udf, Column) or not hasattr(udf, 'func') or not udf.vectorized:
@@ -250,6 +249,7 @@ class GroupedData(object):
         columns = df.columns
 
         def wrapped(*cols):
+            from pyspark.sql.types import to_arrow_type
             import pandas as pd
             result = func(pd.concat(cols, axis=1, keys=columns))
             if not isinstance(result, pd.DataFrame):

--- a/python/pyspark/sql/group.py
+++ b/python/pyspark/sql/group.py
@@ -232,6 +232,7 @@ class GroupedData(object):
 
         """
         from pyspark.sql.functions import pandas_udf
+        from pyspark.sql.types import to_arrow_type
 
         # Columns are special because hasattr always return True
         if isinstance(udf, Column) or not hasattr(udf, 'func') or not udf.vectorized:
@@ -243,14 +244,25 @@ class GroupedData(object):
         func = udf.func
         returnType = udf.returnType
 
-        # The python executors expects the function to take a list of pd.Series as input
+        # The python executors expects the function to use pd.Series as input and output
         # So we to create a wrapper function that turns that to a pd.DataFrame before passing
-        # down to the user function
+        # down to the user function, then turn the result pd.DataFrame back into pd.Series
         columns = df.columns
+        arrow_return_types = [to_arrow_type(field.dataType) for field in returnType]
 
         def wrapped(*cols):
             import pandas as pd
-            return func(pd.concat(cols, axis=1, keys=columns))
+            result = func(pd.concat(cols, axis=1, keys=columns))
+            if not isinstance(result, pd.DataFrame):
+                raise TypeError("Return type of the user-defined function should be "
+                                "Pandas.DataFrame, but is {}".format(type(result)))
+            if not len(result.columns) == len(arrow_return_types):
+                raise RuntimeError(
+                    "Number of columns of the returned Pandas.DataFrame "
+                    "doesn't match specified schema. "
+                    "Expected: {} Actual: {}".format(len(arrow_return_types), len(result.columns)))
+            return [(result[result.columns[i]], arrow_return_types[i])
+                    for i in range(len(arrow_return_types))]
 
         wrapped_udf_obj = pandas_udf(wrapped, returnType)
         udf_column = wrapped_udf_obj(*[df[col] for col in df.columns])

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -74,47 +74,19 @@ def wrap_udf(f, return_type):
 
 
 def wrap_pandas_udf(f, return_type):
-    # If the return_type is a StructType, it indicates this is a groupby apply udf,
-    # otherwise, it's a vectorized column udf.
-    # We can distinguish these two by return type because in groupby apply, we always specify
-    # returnType as a StructType, and in vectorized column udf, StructType is not supported.
-    #
-    # TODO: This logic is a bit hacky and might not work for future pandas udfs. Need refactoring.
-    if isinstance(return_type, StructType):
-        arrow_return_types = [to_arrow_type(field.dataType) for field in return_type]
+    arrow_return_type = to_arrow_type(return_type)
 
-        # Verify the return type and number of columns in result
-        def verify_result_type(*a):
-            import pandas as pd
-            result = f(*a)
-            if not isinstance(result, pd.DataFrame):
-                raise TypeError("Return type of the user-defined function should be "
-                                "Pandas.DataFrame, but is {}".format(type(result)))
-            if not len(result.columns) == len(arrow_return_types):
-                raise RuntimeError(
-                    "Number of columns of the returned Pandas.DataFrame "
-                    "doesn't match specified schema. "
-                    "Expected: {} Actual: {}".format(len(arrow_return_types), len(result.columns)))
+    def verify_result_length(*a):
+        result = f(*a)
+        if not hasattr(result, "__len__"):
+            raise TypeError("Return type of the user-defined functon should be "
+                            "Pandas.Series, but is {}".format(type(result)))
+        if len(result) != len(a[0]):
+            raise RuntimeError("Result vector from pandas_udf was not the required length: "
+                               "expected %d, got %d" % (len(a[0]), len(result)))
+        return result
 
-            return [(result[result.columns[i]], arrow_return_types[i])
-                    for i in range(len(arrow_return_types))]
-
-        return verify_result_type
-
-    else:
-        arrow_return_type = to_arrow_type(return_type)
-
-        def verify_result_length(*a):
-            result = f(*a)
-            if not hasattr(result, "__len__"):
-                raise TypeError("Return type of the user-defined functon should be "
-                                "Pandas.Series, but is {}".format(type(result)))
-            if len(result) != len(a[0]):
-                raise RuntimeError("Result vector from pandas_udf was not the required length: "
-                                   "expected %d, got %d" % (len(a[0]), len(result)))
-            return result
-
-        return lambda *a: (verify_result_length(*a), arrow_return_type)
+    return lambda *a: (verify_result_length(*a), arrow_return_type)
 
 
 def read_single_udf(pickleSer, infile, eval_type):
@@ -129,7 +101,16 @@ def read_single_udf(pickleSer, infile, eval_type):
             row_func = chain(row_func, f)
     # the last returnType will be the return type of UDF
     if eval_type == PythonEvalType.SQL_PANDAS_UDF:
-        return arg_offsets, wrap_pandas_udf(row_func, return_type)
+        # If the return_type is a StructType, it indicates this is a groupby apply udf,
+        # and has already been wrapped under apply(), otherwise, it's a vectorized column udf.
+        # We can distinguish these two by return type because in groupby apply, we always specify
+        # returnType as a StructType, and in vectorized column udf, StructType is not supported.
+        #
+        # TODO: This logic is a bit hacky and might not work for future pandas udfs. Need refactoring.
+        if isinstance(return_type, StructType):
+            return arg_offsets, row_func
+        else:
+            return arg_offsets, wrap_pandas_udf(row_func, return_type)
     else:
         return arg_offsets, wrap_udf(row_func, return_type)
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -74,20 +74,28 @@ def wrap_udf(f, return_type):
 
 
 def wrap_pandas_udf(f, return_type):
-    arrow_return_type = to_arrow_type(return_type)
+    # If the return_type is a StructType, it indicates this is a groupby apply udf,
+    # and has already been wrapped under apply(), otherwise, it's a vectorized column udf.
+    # We can distinguish these two by return type because in groupby apply, we always specify
+    # returnType as a StructType, and in vectorized column udf, StructType is not supported.
+    #
+    # TODO: Look into refactoring use of StructType to be more flexible for future pandas_udfs
+    if isinstance(return_type, StructType):
+        return lambda *a: f(*a)
+    else:
+        arrow_return_type = to_arrow_type(return_type)
 
-    def verify_result_length(*a):
-        result = f(*a)
-        if not hasattr(result, "__len__"):
-            raise TypeError("Return type of the user-defined functon should be "
-                            "Pandas.Series, but is {}".format(type(result)))
-        if len(result) != len(a[0]):
-            raise RuntimeError("Result vector from pandas_udf was not the required length: "
-                               "expected %d, got %d" % (len(a[0]), len(result)))
-        return result
+        def verify_result_length(*a):
+            result = f(*a)
+            if not hasattr(result, "__len__"):
+                raise TypeError("Return type of the user-defined functon should be "
+                                "Pandas.Series, but is {}".format(type(result)))
+            if len(result) != len(a[0]):
+                raise RuntimeError("Result vector from pandas_udf was not the required length: "
+                                   "expected %d, got %d" % (len(a[0]), len(result)))
+            return result
 
-    return lambda *a: (verify_result_length(*a), arrow_return_type)
-
+        return lambda *a: (verify_result_length(*a), arrow_return_type)
 
 def read_single_udf(pickleSer, infile, eval_type):
     num_arg = read_int(infile)
@@ -101,16 +109,7 @@ def read_single_udf(pickleSer, infile, eval_type):
             row_func = chain(row_func, f)
     # the last returnType will be the return type of UDF
     if eval_type == PythonEvalType.SQL_PANDAS_UDF:
-        # If the return_type is a StructType, it indicates this is a groupby apply udf,
-        # and has already been wrapped under apply(), otherwise, it's a vectorized column udf.
-        # We can distinguish these two by return type because in groupby apply, we always specify
-        # returnType as a StructType, and in vectorized column udf, StructType is not supported.
-        #
-        # TODO: This logic is a bit hacky and might not work for future pandas udfs. Need refactoring.
-        if isinstance(return_type, StructType):
-            return arg_offsets, row_func
-        else:
-            return arg_offsets, wrap_pandas_udf(row_func, return_type)
+        return arg_offsets, wrap_pandas_udf(row_func, return_type)
     else:
         return arg_offsets, wrap_udf(row_func, return_type)
 

--- a/python/pyspark/worker.py
+++ b/python/pyspark/worker.py
@@ -97,6 +97,7 @@ def wrap_pandas_udf(f, return_type):
 
         return lambda *a: (verify_result_length(*a), arrow_return_type)
 
+
 def read_single_udf(pickleSer, infile, eval_type):
     num_arg = read_int(infile)
     arg_offsets = [read_int(infile) for i in range(num_arg)]


### PR DESCRIPTION
@icexelloss , I wasn't able to do exactly what I was talking about earlier, but this is along the same lines.  Basically doing the wrapping in one place so it's easy to follow the conversions between Pandas DataFrames and Series.  As a result, it doesn't need to be wrapped in the worker.py.  Buuuut... something isn't quite right and causing a crash. If you think you might use this, I'll put in some more effort and debug it.  It should work, just probably something minor i missed.